### PR TITLE
Metrics/ClassLength - disabled cop for tests, migrations and config files

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -52,6 +52,10 @@ Metrics/BlockLength:
     - config/**/*
 Metrics/ClassLength:
   Max: 200
+  Exclude:
+    - db/migrate/*
+    - test/**/*
+    - config/**/*
 Metrics/CyclomaticComplexity:
   Max: 12
 Metrics/MethodLength:


### PR DESCRIPTION
```
Exclude:
    - db/migrate/*
    - test/**/*
    - config/**/*
```