### PR TITLE
Add rubocop-sorbet as plugin instead of require

### DIFF
--- a/sorbet.yml
+++ b/sorbet.yml
@@ -5,7 +5,9 @@ inherit_mode:
   - Include
 
 inherit_from: ./rubocop.yml
-require: rubocop-sorbet
+
+plugins:
+- rubocop-sorbet
 
 Sorbet/StrictSigil:
   Enabled: false


### PR DESCRIPTION
rubocop-sorbet extension supports plugin, specify `plugins: rubocop-sorbet` instead of `require: rubocop-sorbet` 

For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.