### PR TITLE
Cops for RBS typing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,41 @@
 PATH
   remote: .
   specs:
-    rubocop-espago (1.1.6)
+    rubocop-espago (1.1.8)
       rubocop
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.8.2)
-    language_server-protocol (3.17.0.3)
+    json (2.10.2)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.9.2)
-    rubocop (1.68.0)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rubocop (1.74.0)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.36.1)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   arm64-darwin-20

--- a/rubocop-espago.gemspec
+++ b/rubocop-espago.gemspec
@@ -2,7 +2,7 @@
 
 ::Gem::Specification.new do |s|
   s.name        = 'rubocop-espago'
-  s.version     = '1.1.7'
+  s.version     = '1.1.8'
   s.summary     = "Espago's rubocop config"
   s.description = <<~DESC
     Gem containing the `.rubocop.yml` config used

--- a/sorbet.yml
+++ b/sorbet.yml
@@ -34,3 +34,10 @@ Sorbet/EnforceSignatures:
 Sorbet/HasSigil:
   AutoCorrect: false
   Enabled: false
+
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
+Layout/LineLength:
+  Max: 120
+  AllowedPatterns: ['\A\s*#:']


### PR DESCRIPTION
Allowes long rbs comments (currently it is not possible to write multiline rbs)
Allowes for comments without leading space (rbs comment starts with colon `#:`)